### PR TITLE
Make compatible with JSignPDF 2.0.0

### DIFF
--- a/src/Sign/JSignService.php
+++ b/src/Sign/JSignService.php
@@ -92,7 +92,7 @@ class JSignService
             $jSignPdf = \JSignPDF\JSignPDFBin\JSignPdfPathService::jSignPdfJarPath();
         }
 
-        return "$java -jar $jSignPdf $pdf -ksf $certificate -ksp '{$params->getPassword()}' {$params->getJSignParameters()} -d {$params->getPathPdfSigned()}";
+        return "$java -jar $jSignPdf $pdf -ksf $certificate -ksp '{$params->getPassword()}' {$params->getJSignParameters()} -d {$params->getPathPdfSigned()} 2>&1";
     }
 
     private function javaCommand(JSignParam $params)


### PR DESCRIPTION
On JSignPDF 2.0.0 the log library was changed and the message:
INFO  Finished: Signature succesfully created.
now return:
INFO Finished: Signature succesfully created.
without space between INFO and Finished.

Other impact is the output of error. To catch the output I need put this `2>&1` on end of command.

To make compatible I removed the word INFO