### PR TITLE
Prevent handle invalid output

### DIFF
--- a/src/Sign/JSignService.php
+++ b/src/Sign/JSignService.php
@@ -62,6 +62,9 @@ class JSignService
 
         $command = "$java -jar $jSignPdf --version";
         \exec($command, $output);
+        if (empty($output) || strpos($output[0], 'version') === false) {
+            return '';
+        }
         return explode('version ', $output[0])[1];
     }
 


### PR DESCRIPTION
Prevent to handle `$output` var with invalid value.
If `$output` is empty or haven't `version` string, will return empty version.

I identified maybe a specific scenario with exec command when the `$ouput` get a delay to get the output of command and in this case the `$output` will be empty.

I thought about putting a delay like the follow code to prevent this problem. But, I did this with success, this looked like a more strange workaround to solve the problem. Because of this, I did the more simple, only checking if `$output` have the expected value.

```php
\exec($command, $output);
$loop = 0;
while (empty($output) && $loop < 5) {
    usleep(500000);
    $loop++;
}
```

Maybe, the suggested code here can solve definitively the problem. Waiting for opinions from code review.

Still in time, the scenario in that I found this edge case was in a setup flow when I download the JSignPdf and with other process I do a loop waiting for finish download to check the downloaded version.