### PR TITLE
Redirect stderr to stdout and prevent display error

### DIFF
--- a/src/Sign/JSignService.php
+++ b/src/Sign/JSignService.php
@@ -60,7 +60,7 @@ class JSignService
         }
         $this->throwIf(!file_exists($jSignPdf), 'Jar of JSignPDF not found on path: '. $jSignPdf);
 
-        $command = "$java -jar $jSignPdf --version";
+        $command = "$java -jar $jSignPdf --version 2>&1";
         \exec($command, $output);
         if (empty($output) || strpos($output[0], 'version') === false) {
             return '';


### PR DESCRIPTION
## Problem
When the command return any type of error, the error will be displayed in terminal. JSignPdf display a warning [every time](https://github.com/intoolswetrust/jsignpdf/blob/2d329d6972d669541d64c61c90f0cf8268cf2f20/jsignpdf/src/main/java/net/sf/jsignpdf/utils/PropertyProvider.java#L69-L79) when is executed without the property file.

Ref: https://github.com/LibreSign/libresign/issues/1144

Output with warning:
```
FINE Default property file doesn't exists.
FINE Default property file doesn't exists.
```

## Solution

Redirect `stderr` to `stdout` because the unique necessary output that we need is the last output row of `--version`.

As described in this stackoverflow link, work fine in Linux and in proprietary OS that I won't pronounce the name.

https://stackoverflow.com/questions/818255/what-does-21-mean