### PR TITLE
get only last row

### DIFF
--- a/src/Sign/JSignService.php
+++ b/src/Sign/JSignService.php
@@ -62,10 +62,11 @@ class JSignService
 
         $command = "$java -jar $jSignPdf --version 2>&1";
         \exec($command, $output);
-        if (empty($output) || strpos($output[0], 'version') === false) {
+        $lastRow = end($output);
+        if (empty($output) || strpos($lastRow, 'version') === false) {
             return '';
         }
-        return explode('version ', $output[0])[1];
+        return explode('version ', $lastRow)[1];
     }
 
     private function validation(JSignParam $params)


### PR DESCRIPTION
When JSignPdf havent config file, all executions of jar file return two rows with a warning. This will return every time the last row.