### PR TITLE
fix: works with unicode password

### DIFF
--- a/src/Sign/JSignService.php
+++ b/src/Sign/JSignService.php
@@ -205,7 +205,7 @@ class JSignService
         return [];
     }
 
-    public function exportToPkcs12(\OpenSSLCertificate|string $certificate, \OpenSSLAsymmetricKey|\OpenSSLCertificate|string $privateKey, string $password)
+    private function exportToPkcs12(\OpenSSLCertificate|string $certificate, \OpenSSLAsymmetricKey|\OpenSSLCertificate|string $privateKey, string $password)
     {
         $certContent = null;
         openssl_pkcs12_export(

--- a/src/Sign/JSignService.php
+++ b/src/Sign/JSignService.php
@@ -24,7 +24,7 @@ class JSignService
             $this->validation($params);
 
             $commandSign = $this->commandSign($params);
-            \exec($commandSign, $output);
+            exec($commandSign, $output);
 
             $out            = json_encode($output);
             $messageSuccess = "Finished: Signature succesfully created.";
@@ -84,7 +84,7 @@ class JSignService
         return explode('version ', $lastRow)[1];
     }
 
-    public function validation(JSignParam $params)
+    private function validation(JSignParam $params)
     {
         $this->throwIf(empty($params->getTempPath()) || !is_writable($params->getTempPath()), 'Temp Path is invalid or has not permission to writable.');
         $this->throwIf(empty($params->getPdf()), 'PDF is Empty or Invalid.');

--- a/src/Sign/JSignService.php
+++ b/src/Sign/JSignService.php
@@ -22,6 +22,7 @@ class JSignService
     {
         try {
             $this->validation($params);
+            $this->repackCertificateIfPasswordIsUnicode($params);
 
             $commandSign = $this->commandSign($params);
             \exec($commandSign, $output);
@@ -51,6 +52,22 @@ class JSignService
         }
     }
 
+    /**
+     * JSignPdf don't works as well at CLI interfaceif the password have
+     * unicode chars. As workaround, I changed the password certificate in
+     * memory.
+     */
+    private function repackCertificateIfPasswordIsUnicode(JSignParam $params)
+    {
+        if (!mb_detect_encoding($params->getPassword(), 'ASCII', true)) {
+            $password = md5(microtime());
+            $certInfo = $this->pkcs12Read($params);
+            $newCert = $this->exportToPkcs12($certInfo['cert'], $certInfo['pkey'], $password);
+            $params->setPassword($password);
+            $params->setCertificate($newCert);
+        }
+    }
+
     public function getVersion(JSignParam $params)
     {
         $java     = $this->javaCommand($params);
@@ -75,8 +92,8 @@ class JSignService
         $this->throwIf(empty($params->getPdf()), 'PDF is Empty or Invalid.');
         $this->throwIf(empty($params->getCertificate()), 'Certificate is Empty or Invalid.');
         $this->throwIf(empty($params->getPassword()), 'Certificate Password is Empty.');
-        $this->throwIf(!$this->isPasswordCertificateValid($params->getCertificate(), $params->getPassword()), 'Certificate Password Invalid.');
-        $this->throwIf($this->isExpiredCertificate($params->getCertificate(), $params->getPassword()), 'Certificate expired.');
+        $this->throwIf(!$this->isPasswordCertificateValid($params), 'Certificate Password Invalid.');
+        $this->throwIf($this->isExpiredCertificate($params), 'Certificate expired.');
         if ($params->isUseJavaInstalled()) {
             $javaVersion    = exec("java -version 2>&1");
             $hasJavaVersion = strpos($javaVersion, 'not found') === false;
@@ -135,9 +152,9 @@ class JSignService
             throw new Exception($message);
     }
 
-    private function isPasswordCertificateValid($certificate, $password)
+    private function isPasswordCertificateValid(JSignParam $params)
     {
-        return $this->pkcs12Read($certificate, $password);
+        return $this->pkcs12Read($params);
     }
 
     /**
@@ -153,8 +170,10 @@ class JSignService
      * https://github.com/php/php-src/issues/12128
      * https://www.php.net/manual/en/function.openssl-pkcs12-read.php#128992
      */
-    private function pkcs12Read($certificate, $password)
+    private function pkcs12Read(JSignParam $params)
     {
+        $certificate = $params->getCertificate();
+        $password = $params->getPassword();
         if (openssl_pkcs12_read($certificate, $certInfo, $password)) {
             return $certInfo;
         }
@@ -175,6 +194,7 @@ class JSignService
                 REPACK_COMMAND
             );
             $certificateRepacked = file_get_contents($tempEncriptedRepacked);
+            $params->setCertificate($certificateRepacked);
             unlink($tempPassword);
             unlink($tempEncriptedOriginal);
             unlink($tempEncriptedRepacked);
@@ -185,9 +205,21 @@ class JSignService
         return [];
     }
 
-    private function isExpiredCertificate($certificate, $password)
+    public function exportToPkcs12(\OpenSSLCertificate|string $certificate, \OpenSSLAsymmetricKey|\OpenSSLCertificate|string $privateKey, string $password)
     {
-        $certInfo = $this->pkcs12Read($certificate, $password);
+        $certContent = null;
+        openssl_pkcs12_export(
+            $certificate,
+            $certContent,
+            $privateKey,
+            $password,
+        );
+        return $certContent;
+    }
+
+    private function isExpiredCertificate(JSignParam $params)
+    {
+        $certInfo = $this->pkcs12Read($params);
         $certificate = openssl_x509_parse($certInfo['cert']);
         $dateCert    = date_create()->setTimestamp($certificate['validTo_time_t']);
         return $dateCert <= date_create();

--- a/tests/JSignPDFTest.php
+++ b/tests/JSignPDFTest.php
@@ -3,12 +3,12 @@
 namespace Jeidison\JSignPDF\Sign;
 
 function exec(string $command, array &$output = null, int &$return_var = null) {
-	global $mockExec;
-	if ($mockExec) {
-		$output = $mockExec;
-		return $output;
-	}
-	return \exec($command, $output, $return_var);
+    global $mockExec;
+    if ($mockExec) {
+        $output = $mockExec;
+        return $output;
+    }
+    return \exec($command, $output, $return_var);
 }
 
 namespace Jeidison\JSignPDF\Tests;
@@ -27,8 +27,8 @@ class JSignPDFTest extends TestCase
 
     protected function setUp(): void
     {
-		global $mockExec;
-		$mockExec = null;
+        global $mockExec;
+        $mockExec = null;
         $this->service = new JSignService();
     }
 
@@ -54,7 +54,14 @@ class JSignPDFTest extends TestCase
         $temporaryFile = tempnam(sys_get_temp_dir(), 'cfg');
         $csr = openssl_csr_new($csrNames, $privateKey);
         $x509 = openssl_csr_sign($csr, $rootCertificate, $rootPrivateKey, 365);
-        return $this->service->exportToPkcs12($x509, $privateKey, $password);
+        $certContent = null;
+        openssl_pkcs12_export(
+            $x509,
+            $certContent,
+            $privateKey,
+            $password,
+        );
+        return $certContent;
     }
 
     public function testSignSuccess()
@@ -73,16 +80,16 @@ class JSignPDFTest extends TestCase
      */
     public function testSignUsingDifferentPasswords(string $password)
     {
-		global $mockExec;
+        global $mockExec;
         if (!class_exists('JSignPDF\JSignPDFBin\JavaCommandService')) {
             $this->markTestSkipped('Install jsignpdf/jsignpdf-bin');
         }
         $params = JSignParamBuilder::instance()->withDefault();
         $params->setCertificate($this->getNewCert($password));
         $params->setPassword($password);
-		$mockExec = 'Finished: Signature succesfully created.';
-		$path = $params->getTempPdfSignedPath();
-		file_put_contents($path, 'dummy');
+        $mockExec = 'Finished: Signature succesfully created.';
+        $path = $params->getTempPdfSignedPath();
+        file_put_contents($path, 'dummy');
         $fileSigned = $this->service->sign($params);
         $this->assertNotNull($fileSigned);
     }

--- a/tests/JSignPDFTest.php
+++ b/tests/JSignPDFTest.php
@@ -57,6 +57,7 @@ class JSignPDFTest extends TestCase
 
     /**
      * @dataProvider providerSignUsingDifferentPasswords
+     * @doesNotPerformAssertions
      */
     public function testSignUsingDifferentPasswords(string $password)
     {
@@ -66,8 +67,7 @@ class JSignPDFTest extends TestCase
         $params = JSignParamBuilder::instance()->withDefault();
         $params->setCertificate($this->getNewCert($password));
         $params->setPassword($password);
-        $fileSigned = $this->service->sign($params);
-        $this->assertNotNull($fileSigned);
+        $this->service->validation($params);
     }
 
     public function providerSignUsingDifferentPasswords()


### PR DESCRIPTION
JSignPdf don't works as well at CLI interfaceif the password have unicode chars. As workaround, I changed the password certificate in memory.

![Screenshot_20240423_172828](https://github.com/JSignPdf/jsignpdf-php/assets/1079143/e00318f3-ae78-4cd4-83eb-dc225cfeb967)

When we use a certificate with an unicode char at password will throw this error:
```
Exception: Error to sign PDF. [
	"FINE Default property file doesn't exists.",
	"FINE Default property file doesn't exists.",
	"INFO Checking input and output PDF paths.",
	"java.io.IOException: keystore password was incorrect",
	"\tat java.base\/sun.security.pkcs12.PKCS12KeyStore.engineLoad(Unknown Source)",
	"\tat java.base\/sun.security.util.KeyStoreDelegator.engineLoad(Unknown Source)",
	"\tat java.base\/java.security.KeyStore.load(Unknown Source)",
	"\tat net.sf.jsignpdf.utils.KeyStoreUtils.loadKeyStore(KeyStoreUtils.java:359)",
	"\tat net.sf.jsignpdf.utils.KeyStoreUtils.getPkInfo(KeyStoreUtils.java:411)",
	"\tat net.sf.jsignpdf.SignerLogic.signFile(SignerLogic.java:154)",
	"\tat net.sf.jsignpdf.Signer.signFiles(Signer.java:246)",
	"\tat net.sf.jsignpdf.Signer.main(Signer.java:139)",
	"Caused by: java.security.UnrecoverableKeyException: failed to decrypt safe contents entry: javax.crypto.BadPaddingException: Given final block not properly padded. Such issues can arise if a bad key is used during decryption.",
	"\t... 8 more",
	"WARNING Keystore was not loaded succesfully. Check if the keystore type, path and password are valid.",
	"SEVERE Problem occured",
	"java.lang.NullPointerException: Keystore was not loaded succesfully. Check if the keystore type, path and password are valid.",
	"\tat net.sf.jsignpdf.utils.KeyStoreUtils.getKeyAliasInternal(KeyStoreUtils.java:224)",
	"\tat net.sf.jsignpdf.utils.KeyStoreUtils.getPkInfo(KeyStoreUtils.java:413)",
	"\tat net.sf.jsignpdf.SignerLogic.signFile(SignerLogic.java:154)",
	"\tat net.sf.jsignpdf.Signer.signFiles(Signer.java:246)",
	"\tat net.sf.jsignpdf.Signer.main(Signer.java:139)",
	"",
	"INFO Finished: Creating of signature failed."
]
```
