### PR TITLE
fix: set user language hardcoded

### DIFF
--- a/src/Sign/JSignService.php
+++ b/src/Sign/JSignService.php
@@ -127,7 +127,7 @@ class JSignService
         $this->throwIf(!file_exists($jSignPdf), 'Jar of JSignPDF not found on path: '. $jSignPdf);
 
         $password = escapeshellarg($params->getPassword());
-        return "$java -jar $jSignPdf $pdf -ksf $certificate -ksp {$password} {$params->getJSignParameters()} -d {$params->getPathPdfSigned()} 2>&1";
+        return "$java -Duser.language=en -jar $jSignPdf $pdf -ksf $certificate -ksp {$password} {$params->getJSignParameters()} -d {$params->getPathPdfSigned()} 2>&1";
     }
 
     private function javaCommand(JSignParam $params)


### PR DESCRIPTION
The problem:

The follow code verify the string in English, but if the operational system is in another language, don't will match the string:

https://github.com/JSignPdf/jsignpdf-php/blob/v1.2.5/src/Sign/JSignService.php#L30-L33

English text: Finished: Signature succesfully created.
German text: Fertig: Signatur erfolgreich erzeugt.

To solve was necessary to mahe the java user language hardcoded as English.

Ref:
- https://github.com/LibreSign/libresign/issues/4127