### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vitormattos @jeidison


### PR DESCRIPTION
Make more easy to add who will review a pull request at GitHub.

Ref:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners