### PR TITLE
fix: add suffix to test files

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,7 @@
 
     <testsuites>
         <testsuite name="Units Test">
-            <directory suffix=".php">./tests</directory>
+            <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
Without this, all php files at tests folder will be executed by PHPUnit as a test file, but we have files that isn't test classes inside this folder.