### PR TITLE
fix: use custom java path

### DIFF
--- a/src/Runtime/JavaRuntimeService.php
+++ b/src/Runtime/JavaRuntimeService.php
@@ -23,10 +23,7 @@ class JavaRuntimeService
         $downloadUrl = $params->getJavaDownloadUrl();
 
         if ($javaPath && !$downloadUrl) {
-            if (is_file($javaPath) && is_executable($javaPath)) {
-                return $javaPath;
-            }
-            throw new InvalidArgumentException('Java path defined is not executable: ' . $javaPath);
+            return $javaPath;
         }
 
         if ($downloadUrl && $javaPath) {

--- a/tests/Runtime/JavaRuntimeServiceTest.php
+++ b/tests/Runtime/JavaRuntimeServiceTest.php
@@ -43,15 +43,15 @@ class JavaRuntimeServiceTest extends TestCase
         $this->assertEquals('vfs://download/bin/java', $path);
     }
 
-    public function testGetPathWithCustomAndInvalidJavaPath(): void
+    public function testGetPathWithCustomJavaPath(): void
     {
         $jsignParam = new JSignParam();
         $service = new JavaRuntimeService();
-        $jsignParam->setJavaPath(__FILE__);
+        $expectedPath = __FILE__;
+        $jsignParam->setJavaPath($expectedPath);
         $jsignParam->setJavaDownloadUrl('');
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/not executable/');
-        $service->getPath($jsignParam);
+        $actual = $service->getPath($jsignParam);
+        $this->assertEquals($expectedPath, $actual);
     }
 
     public function testGetPathWithDownloadUrlAndNotRealDirectory(): void


### PR DESCRIPTION
We can add environments before the java path and parameters to java binary like the follow code:

```bash
JSIGNPDF_HOME=/jsignpdf /java/bin/java -Duser.home=/jsignpdf/
```

When check if javaPath is a file, won't work at this scenario and we need to believe that the path is OK.