### PR TITLE
feat: add docker environment to run the checks locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:8.4-cli
+
+# zip: ZipArchive in JSignPdfRuntimeService | sockets: donatj/mock-webserver in the tests
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libzip-dev unzip \
+ && docker-php-ext-install zip sockets \
+ && rm -rf /var/lib/apt/lists/*
+
+# PharData exceeds the default 128M just to open the JRE tarball
+RUN echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/app.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM php:8.4-cli
 
 # zip: ZipArchive in JSignPdfRuntimeService | sockets: donatj/mock-webserver in the tests
-RUN apt-get update \
- && apt-get install -y --no-install-recommends libzip-dev unzip \
- && docker-php-ext-install zip sockets \
- && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod uga+x /usr/local/bin/install-php-extensions && sync \
+ && install-php-extensions \
+    sockets \
+    zip \
+    @composer \
+ && rm /usr/local/bin/install-php-extensions
 
 # PharData exceeds the default 128M just to open the JRE tarball
 RUN echo 'memory_limit=512M' > /usr/local/etc/php/conf.d/app.ini
-
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -64,5 +64,38 @@ Change parameters of JSignPDF:
 $param->setJSignParameters("-a -kst PKCS12 -ts https://freetsa.org/tsr");
 ```
 
+## Docker Environment
+
+The repository ships a minimal Docker setup (`Dockerfile` and `compose.yml`) with PHP 8.4 and the
+extensions the test suite needs. Adjust the `user:` line in `compose.yml` to your own `id -u`/`id -g`
+so the files it writes are not owned by root.
+
+```bash
+docker compose build
+docker compose run --rm php composer install
+```
+
+Checks, the same ones the CI runs:
+
+```bash
+docker compose run --rm php composer run test:unit
+docker compose run --rm php composer run cs:check   # cs:fix to apply the formatting
+docker compose run --rm php composer run psalm
+```
+
+To sign a PDF end to end. It downloads the JRE and the JSignPdf jar into `tmp/` on the first run:
+
+```bash
+docker compose run --rm php php example/index.php
+```
+
+The cached runtime left in `tmp/` makes `JavaRuntimeServiceTest` fail. Remove the whole directory
+before running the suite again, not only the version marker, otherwise the next download cannot
+overwrite the extracted JRE:
+
+```bash
+rm -rf tmp/java tmp/jsignpdf
+```
+
 ## Credits
 - [Jeidison Farias](https://github.com/jeidison)

--- a/README.md
+++ b/README.md
@@ -66,9 +66,8 @@ $param->setJSignParameters("-a -kst PKCS12 -ts https://freetsa.org/tsr");
 
 ## Docker Environment
 
-The repository ships a minimal Docker setup (`Dockerfile` and `compose.yml`) with PHP 8.4 and the
-extensions the test suite needs. Adjust the `user:` line in `compose.yml` to your own `id -u`/`id -g`
-so the files it writes are not owned by root.
+The repository ships a minimal Docker setup (`Dockerfile` and `compose.yml`) with the extensions
+the test suite needs.
 
 ```bash
 docker compose build

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ docker compose run --rm php composer run cs:check   # cs:fix to apply the format
 docker compose run --rm php composer run psalm
 ```
 
+### Usage example
+
 To sign a PDF end to end. It downloads the JRE and the JSignPdf jar into `tmp/` on the first run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -88,13 +88,5 @@ To sign a PDF end to end. It downloads the JRE and the JSignPdf jar into `tmp/` 
 docker compose run --rm php php example/index.php
 ```
 
-The cached runtime left in `tmp/` makes `JavaRuntimeServiceTest` fail. Remove the whole directory
-before running the suite again, not only the version marker, otherwise the next download cannot
-overwrite the extracted JRE:
-
-```bash
-rm -rf tmp/java tmp/jsignpdf
-```
-
 ## Credits
 - [Jeidison Farias](https://github.com/jeidison)

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,9 @@
+services:
+  php:
+    build: .
+    # your own uid:gid, so vendor/ is not written as root (see: id -u; id -g)
+    user: "1000:1000"
+    environment:
+      COMPOSER_HOME: /tmp/composer
+    volumes:
+      - .:/app

--- a/compose.yml
+++ b/compose.yml
@@ -1,8 +1,8 @@
 services:
   php:
     build: .
-    # your own uid:gid, so vendor/ is not written as root (see: id -u; id -g)
-    user: "1000:1000"
+    # export HOST_UID/HOST_GID if yours are not 1000, so the files it writes are yours (see: id -u; id -g)
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     environment:
       COMPOSER_HOME: ${COMPOSER_HOME:-/tmp/composer}
     volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -4,6 +4,6 @@ services:
     # your own uid:gid, so vendor/ is not written as root (see: id -u; id -g)
     user: "1000:1000"
     environment:
-      COMPOSER_HOME: /tmp/composer
+      COMPOSER_HOME: ${COMPOSER_HOME:-/tmp/composer}
     volumes:
       - .:/app

--- a/tests/Runtime/JavaRuntimeServiceTest.php
+++ b/tests/Runtime/JavaRuntimeServiceTest.php
@@ -170,6 +170,7 @@ class JavaRuntimeServiceTest extends TestCase
         $baseUrl = $server->getServerRoot();
         $url = $baseUrl . '/OpenJDK21U-jre_x64_linux_hotspot_21.0.8_9.tar.gz';
         $jsignParam->setJavaDownloadUrl($url);
+        $jsignParam->setJavaPath($this->testTmpDir . '/bin/java');
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/cannot be extracted/');


### PR DESCRIPTION
## Why

Running the checks locally depends on the host's PHP and OpenSSL, and on distributions where those differ from CI the suite fails for reasons that have nothing to do with the library. On Fedora 44 (PHP 8.5.9, OpenSSL 3.5.7) none of the three checks behave like they do on CI:

- `composer run test:unit` fails with 6 errors and 2 failures, all of them  `setCertificate(): Argument #1 must be of type string, null given`. The test helper calls `openssl_csr_sign()` without `digest_alg`, so PHP signs the generated certificate with SHA-1, and the distribution's crypto policy rejects it (`rh-allow-sha1-signatures = no`, `error:03000098 ... invalid digest`). The certificate comes back `null`. This affects Fedora and RHEL 9+ by default.
- `composer run psalm` does not run at all. Psalm 6.5.0 turns PHP 8.5's `SplObjectStorage::attach()` deprecation into an uncaught `Throwable` and crashes before analysing anything. Silencing deprecations does not help, since the crash comes from Psalm's own error handler.
- `example/index.php` dies with a fatal error, because `PharData` exceeds the default 128M memory limit just to open the JRE tarball. The fatal skips the `catch`, so the temporary `.pfx` is left behind with its private key.